### PR TITLE
Permite que o repositório de cartas seja sobescrito.

### DIFF
--- a/editor-de-servicos/docker-compose.yml
+++ b/editor-de-servicos/docker-compose.yml
@@ -7,7 +7,7 @@
     JAVA_OPTS: '-Dfile.encoding=UTF-8 -Xms256M -Xmx1G -Djava.awt.headless=true -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly -XX:+HeapDumpOnOutOfMemoryError -XX:+DisableExplicitGC'
     SPRING_THYMELEAF_CACHE: true
     FLAGS_GIT_PUSH: true
-    EDS_CARTAS_REPOSITORIO: 'git@github.com:servicosgovbr/cartas-de-servico.git'
+    EDS_CARTAS_REPOSITORIO: "${EDS_CARTAS_REPOSITORIO}"
     ENDPOINTS_ENABLED: false
     ENDPOINTS_JOLOKIA_ENABLED: false
     ENDPOINTS_INFO_ENABLED: true

--- a/portal-de-servicos/docker-compose.yml
+++ b/portal-de-servicos/docker-compose.yml
@@ -5,7 +5,7 @@ portal-de-servicos:
     JAVA_OPTS: '-Dfile.encoding=UTF-8 -Xms256M -Xmx1G -Djava.awt.headless=true -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly -XX:+HeapDumpOnOutOfMemoryError -XX:+DisableExplicitGC'
     SPRING_DATA_ELASTICSEARCH_CLUSTERNODES: "es1:9300,es2:9300"
     SPRING_THYMELEAF_CACHE: true
-    PDS_CARTAS_REPOSITORIO: "https://github.com/servicosgovbr/cartas-de-servico.git"
+    PDS_CARTAS_REPOSITORIO: "${PDS_CARTAS_REPOSITORIO}"
     PDS_IMPORTADOR_INTERVALO: "600000"
     PDS_PIWIK_ENABLED: false
     PDS_PIWIK_URL: "https://estatisticas.presidencia.gov.br/"

--- a/scripts/update_editor_container
+++ b/scripts/update_editor_container
@@ -5,6 +5,9 @@ set -o pipefail
 cd '/root/docker'
 git pull --rebase
 
+REPOSITORIO_CARTAS_PADRAO_EDITOR='git@github.com:servicosgovbr/cartas-de-servico.git'
+export EDS_CARTAS_REPOSITORIO="${EDS_CARTAS_REPOSITORIO:-$REPOSITORIO_CARTAS_PADRAO_EDITOR}"
+
 docker-compose stop editor1 editor2
 docker-compose kill editor1 editor2
 docker-compose rm -f editor1 editor2

--- a/scripts/update_editor_portal_container
+++ b/scripts/update_editor_portal_container
@@ -5,6 +5,12 @@ set -o pipefail
 cd '/root/docker'
 git pull --rebase
 
+REPOSITORIO_CARTAS_PADRAO_EDITOR='git@github.com:servicosgovbr/cartas-de-servico.git'
+export EDS_CARTAS_REPOSITORIO="${EDS_CARTAS_REPOSITORIO:-$REPOSITORIO_CARTAS_PADRAO_EDITOR}"
+
+REPOSITORIO_CARTAS_PADRAO_PORTAL='https://github.com/servicosgovbr/cartas-de-servico.git'
+export PDS_CARTAS_REPOSITORIO="${PDS_CARTAS_REPOSITORIO:-$REPOSITORIO_CARTAS_PADRAO_PORTAL}"
+
 docker-compose stop editor1 editor2 portal1 portal2
 docker-compose kill editor1 editor2 portal1 portal2
 docker-compose rm -f editor1 editor2 portal1 portal2

--- a/scripts/update_portal_container
+++ b/scripts/update_portal_container
@@ -5,6 +5,9 @@ set -o pipefail
 cd '/root/docker'
 git pull --rebase
 
+REPOSITORIO_CARTAS_PADRAO_PORTAL='https://github.com/servicosgovbr/cartas-de-servico.git'
+export PDS_CARTAS_REPOSITORIO="${PDS_CARTAS_REPOSITORIO:-$REPOSITORIO_CARTAS_PADRAO_PORTAL}"
+
 docker-compose stop portal1 portal2
 docker-compose kill portal1 portal2
 docker-compose rm -f portal1 portal2


### PR DESCRIPTION
Para que possamos utilizar diferentes repositórios de cartas dependendo
do ambiente, utilizamos váriaveis de ambiente para permitir sobescrever
a fonte de informações.

Caso essa váriavel de ambiente não esteja presente, utilizamos o valor
padrão do repositório no GitHub servicosgovbr/cartas-de-servico.
