### PR TITLE
Força a parada de todos os serviços durante a atualização.

### DIFF
--- a/scripts/update_portal_de_servicos
+++ b/scripts/update_portal_de_servicos
@@ -13,9 +13,9 @@ export PDS_CARTAS_REPOSITORIO="${PDS_CARTAS_REPOSITORIO:-$REPOSITORIO_CARTAS_PAD
 
 ./build-all
 
-docker-compose stop editor1 editor2 portal1 portal2
-docker-compose kill editor1 editor2 portal1 portal2
-docker-compose rm -f editor1 editor2 portal1 portal2
+docker-compose stop editor1 editor2 portal1 portal2 logstash kibana es1 es2 postgres
+docker-compose kill editor1 editor2 portal1 portal2 logstash kibana es1 es2 postgres
+docker-compose rm -f editor1 editor2 portal1 portal2 logstash kibana es1 es2 postgres
 
 docker-compose up -d
 docker-compose restart balanceador


### PR DESCRIPTION
Durante o processo de atualização, estamos acertando um erro[1] do
Docker quando ele tenta lidar com alguns processos.

Isso ocorre quando o docker compose precisa atualizar um dos processos,
mas ele está ocupado processando informações. Isso faz com que tenhamos
a mensagem:

```
Failed to remove root filesystem
```

Para evitar isso, iremos parar todo o serviços, para dar tempo do
serviço processar a informação e parar.

[1] https://github.com/docker/docker/issues/5684
