### PR TITLE
Troca o processo shell no container para a aplicação que iremos executar

### DIFF
--- a/balanceador/run.sh
+++ b/balanceador/run.sh
@@ -10,4 +10,4 @@ if [ ! -f /etc/ssl/private/SERVICOSGOVBR.pem ]; then
    sed -i  '/Secure if secure/d' $HAPROXY
 fi 
 
-haproxy -f $HAPROXY
+exec haproxy -f $HAPROXY

--- a/editor-de-servicos/run.sh
+++ b/editor-de-servicos/run.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-pushd /var/lib/editor-de-servicos
-  exec /opt/editor-de-servicos/bin/editor-de-servicos
-popd
+cd /var/lib/editor-de-servicos
+exec /opt/editor-de-servicos/bin/editor-de-servicos

--- a/editor-de-servicos/run.sh
+++ b/editor-de-servicos/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 pushd /var/lib/editor-de-servicos
-  /opt/editor-de-servicos/bin/editor-de-servicos
+  exec /opt/editor-de-servicos/bin/editor-de-servicos
 popd

--- a/portal-de-servicos/run.sh
+++ b/portal-de-servicos/run.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-pushd /var/lib/portal-de-servicos
-  exec /opt/portal-de-servicos/bin/portal-de-servicos
-popd
+cd /var/lib/portal-de-servicos
+exec /opt/portal-de-servicos/bin/portal-de-servicos

--- a/portal-de-servicos/run.sh
+++ b/portal-de-servicos/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 pushd /var/lib/portal-de-servicos
-  /opt/portal-de-servicos/bin/portal-de-servicos
+  exec /opt/portal-de-servicos/bin/portal-de-servicos
 popd


### PR DESCRIPTION
Processos em ambientes Linux utilizam sinais para comunicar mudanças,
como quando são pedidos para parar um processo ou recarregar
configurações.

Containers Docker conseguem repassar esses sinais para o processo que
ele iniciou, mas alguns dos nossos casos, o processo inicial é um shell
Bash. Shells Bash não repassam sinais para os processos filhos por
padrão, o que pode levar que alguns containeres fiquem não responssivos.

Esse commit utiliza o comando `exec` para repassar a responsabilidade do
processo Bash, após processar o que for necessário, para o processo
filho.

Isso efetivamente troca o processo que está sendo executado no momento,
removendo o processo Bash da cadeia de processamento de sinais.
### Exemplo

Anteriormente, o container HAProxy estava assim:

```
Docker container -> Bash -> HAProxy
```

Ao enviar um `docker kill` para o container, o processo Bash receberia
um sinal de parada, mas não necessariamente repassaria para o processo
HAProxy. Isso impede que o processo interno tenha tempo para limpar
qualquer coisa antes que um sinal de parada definitiva seja enviado.

Agora hierarquia de proceso será assim:

```
Docker container -> HAProxy
```

Após processar a informação necessaria no processo Bash, iremos trocar o
processo para o processo filho diretamente. Os sinais agora serão
enviados ao processo filho.

Mais detalhes disso estão disponiveis 'Scenario 1: A shell as PID 1' no
seguinte [post](http://engineeringblog.yelp.com/2016/01/dumb-init-an-init-for-docker.html)
